### PR TITLE
feat: add composable multicall

### DIFF
--- a/src/contract.cairo
+++ b/src/contract.cairo
@@ -1,8 +1,11 @@
 #[starknet::contract]
 mod ComposableMulticall {
+    use core::array::ArrayTrait;
+    use core::array::SpanTrait;
     use starknet::ContractAddress;
     use starknet::{get_caller_address, get_contract_address};
-    use composable_multicall::{IComposableMulticall, DynamicCall};
+    use composable_multicall::{IComposableMulticall, DynamicCall, DynamicInput};
+    use starknet::call_contract_syscall;
 
     #[storage]
     struct Storage {
@@ -13,7 +16,66 @@ mod ComposableMulticall {
     #[external(v0)]
     impl ComposableMulticallImpl of IComposableMulticall<ContractState> {
         fn aggregate(self: @ContractState, calls: Array<DynamicCall>) -> Array<Span<felt252>> {
-            Default::default()
+            execute_multicall(calls.span())
         }
+    }
+
+    fn build_inputs(
+        call_outputs: @Array<Span<felt252>>, mut dynamic_inputs: Span::<DynamicInput>
+    ) -> Array::<felt252> {
+        let mut output: Array<felt252> = Default::default();
+        loop {
+            match dynamic_inputs.pop_front() {
+                Option::Some(dynamic_input) => {
+                    match dynamic_input {
+                        DynamicInput::Hardcoded(value) => { output.append(*value); },
+                        DynamicInput::Reference((
+                            call_id, felt_id
+                        )) => {
+                            let call_output = *call_outputs.at(*call_id);
+                            let felt = call_output.at(*felt_id);
+                            output.append(*felt);
+                        }
+                    }
+                },
+                Option::None => { break; }
+            }
+        };
+        output
+    }
+
+    fn execute_multicall(mut calls: Span<DynamicCall>) -> Array<Span<felt252>> {
+        let mut result: Array<Span<felt252>> = ArrayTrait::new();
+        let mut idx = 0;
+        loop {
+            match calls.pop_front() {
+                Option::Some(call) => {
+                    match call_contract_syscall(
+                        *call.to, *call.selector, build_inputs(@result, call.calldata.span()).span()
+                    ) {
+                        Result::Ok(retdata) => {
+                            result.append(retdata);
+                            idx = idx + 1;
+                        },
+                        Result::Err(mut revert_reason) => {
+                            let mut data = ArrayTrait::new();
+                            data.append('starknetid/multicall-failed');
+                            data.append(idx);
+
+                            loop {
+                                match revert_reason.pop_front() {
+                                    Option::Some(item) => { data.append(item); },
+                                    Option::None(()) => { break; },
+                                };
+                            };
+
+                            panic(data);
+                        },
+                    }
+                },
+                Option::None(_) => { break; },
+            };
+        };
+        result
     }
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -6,7 +6,7 @@ mod tests;
 enum DynamicInput {
     Hardcoded: felt252,
     // call, output call
-    Reference: (felt252, felt252),
+    Reference: (usize, usize),
 }
 
 #[derive(Drop, Serde)]

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -1,8 +1,13 @@
+use core::array::SpanTrait;
+use core::array::ArrayTrait;
+use composable_multicall::IComposableMulticallDispatcherTrait;
 use starknet::{
     testing::set_contract_address, class_hash::Felt252TryIntoClassHash, ContractAddress,
     SyscallResultTrait
 };
-use composable_multicall::{contract::ComposableMulticall, IComposableMulticallDispatcher};
+use composable_multicall::{
+    DynamicCall, DynamicInput, contract::ComposableMulticall, IComposableMulticallDispatcher
+};
 
 #[starknet::interface]
 trait IDummy<TState> {
@@ -25,17 +30,24 @@ mod DummyContract {
 
     #[external(v0)]
     impl DummyImpl of super::IDummy<ContractState> {
+        // 0x039674cadb16109ec414e371cc8f04eb60a540c52d4880cadb49dfafb8d79797
         fn multiply(self: @ContractState, x: felt252, y: felt252) -> felt252 {
             x * y
         }
+        // 0x035a8bb8492337e79bdc674d6f31ac448f8017e26cc7bfe3144fb5d886fe5369
         fn add(self: @ContractState, x: felt252, y: felt252) -> felt252 {
             x + y
         }
+        // 0x03dc111d7c3ad1df9806ce1e8eb4f55f57dba117339c545e7593d1f6c3b02662
         fn one(self: @ContractState) -> felt252 {
             1
         }
     }
 }
+
+const ONE_SELECTOR: felt252 = 0x03dc111d7c3ad1df9806ce1e8eb4f55f57dba117339c545e7593d1f6c3b02662;
+const ADD_SELECTOR: felt252 = 0x035a8bb8492337e79bdc674d6f31ac448f8017e26cc7bfe3144fb5d886fe5369;
+const MUL_SELECTOR: felt252 = 0x039674cadb16109ec414e371cc8f04eb60a540c52d4880cadb49dfafb8d79797;
 
 fn deploy() -> (IComposableMulticallDispatcher, IDummyDispatcher) {
     let (cm_address, _) = starknet::deploy_syscall(
@@ -62,3 +74,93 @@ fn test_dummy_contract() {
     assert(dummy.add(dummy.multiply(2, 3), dummy.one()) == 7, 'invalid result');
 }
 
+use debug::PrintTrait;
+
+#[test]
+#[available_gas(2000000000)]
+fn test_simple_call() {
+    // [ one() ]
+
+    let (multicall, dummy) = deploy();
+    let result = multicall
+        .aggregate(
+            array![
+                DynamicCall {
+                    to: dummy.contract_address, selector: ONE_SELECTOR, calldata: array![]
+                }
+            ]
+        );
+
+    assert(result.len() == 1, 'Invalid result length');
+    let first_call_result = *result.at(0);
+    assert(first_call_result.len() == 1, 'Invalid 1st result length');
+    assert(*first_call_result.at(0) == 1, 'Invalid 1st result value');
+}
+
+#[test]
+#[available_gas(2000000000)]
+fn test_chained_calls() {
+    // [ one(), add(1, 2) ]
+
+    let (multicall, dummy) = deploy();
+    let result = multicall
+        .aggregate(
+            array![
+                DynamicCall {
+                    to: dummy.contract_address, selector: ONE_SELECTOR, calldata: array![]
+                },
+                DynamicCall {
+                    to: dummy.contract_address,
+                    selector: ADD_SELECTOR,
+                    calldata: array![DynamicInput::Hardcoded(1), DynamicInput::Hardcoded(2)]
+                }
+            ]
+        );
+
+    assert(result.len() == 2, 'Invalid result length');
+    let first_call_result = *result.at(0);
+    assert(first_call_result.len() == 1, 'Invalid 1st result length');
+    assert(*first_call_result.at(0) == 1, 'Invalid 1st result value');
+    let second_call_result = *result.at(1);
+    assert(second_call_result.len() == 1, 'Invalid 2nd result length');
+    assert(*second_call_result.at(0) == 3, 'Invalid 2nd result value');
+}
+
+
+#[test]
+#[available_gas(2000000000)]
+fn test_composed_calls() {
+    // multiply( add(one(), 2), 2)
+
+    let (multicall, dummy) = deploy();
+    let result = multicall
+        .aggregate(
+            array![
+                DynamicCall {
+                    to: dummy.contract_address, selector: ONE_SELECTOR, calldata: array![]
+                },
+                DynamicCall {
+                    to: dummy.contract_address,
+                    selector: ADD_SELECTOR,
+                    calldata: array![DynamicInput::Reference((0, 0)), DynamicInput::Hardcoded(2)]
+                },
+                DynamicCall {
+                    to: dummy.contract_address,
+                    selector: MUL_SELECTOR,
+                    calldata: array![DynamicInput::Reference((1, 0)), DynamicInput::Hardcoded(2)]
+                }
+            ]
+        );
+
+    assert(result.len() == 3, 'Invalid result length');
+    let first_call_result = *result.at(0);
+    assert(first_call_result.len() == 1, 'Invalid 1st result length');
+    assert(*first_call_result.at(0) == 1, 'Invalid 1st result value');
+    let second_call_result = *result.at(1);
+    assert(second_call_result.len() == 1, 'Invalid 2nd result length');
+    assert(*second_call_result.at(0) == 3, 'Invalid 2nd result value');
+
+    let third_call_result = *result.at(2);
+    assert(third_call_result.len() == 1, 'Invalid 3d result length');
+    assert(*third_call_result.at(0) == 6, 'Invalid 3d result value');
+}


### PR DESCRIPTION
This adds a way to compose calls (use the output of a previous call as the input of a following call). This also adds a few tests to showcase how to use it.